### PR TITLE
Enhance `Routes` with `DisableRequests` functionality

### DIFF
--- a/src/Devlead.Testing.MockHttp.Tests/Constants.cs
+++ b/src/Devlead.Testing.MockHttp.Tests/Constants.cs
@@ -2,4 +2,9 @@ namespace Devlead.Testing.MockHttp.Tests;
 
 public class Constants
 {
+    public class Uris
+    {
+        public const string Index_Txt = "https://example.com/index.txt";
+        public const string New_Txt = "https://example.com/new.txt";
+    }
 }

--- a/src/Devlead.Testing.MockHttp.Tests/Devlead.Testing.MockHttp.Tests.csproj
+++ b/src/Devlead.Testing.MockHttp.Tests/Devlead.Testing.MockHttp.Tests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="NUnit" />
     <PackageReference Include="NUnit.Analyzers" />
     <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="System.Linq.Async" />
     <PackageReference Include="Verify.NUnit" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="Verify.Http" VersionOverride="6.4.1" Condition="'$(TargetFramework)' != 'net9.0'" />

--- a/src/Devlead.Testing.MockHttp.Tests/Resources/Routes.json
+++ b/src/Devlead.Testing.MockHttp.Tests/Resources/Routes.json
@@ -41,5 +41,74 @@
         "StatusCode": 200
       }
     ]
+  },
+  {
+    "Request": {
+      "Methods": [
+        {
+          "Method": "PUT"
+        }
+      ],
+      "AbsoluteUri": "https://example.com/new.txt"
+    },
+    "Responses": [
+      {
+        "StatusCode": 201,
+        "EnableRequests": [
+          {
+            "Method": "GET",
+            "AbsoluteUri": "https://example.com/new.txt"
+          },
+
+          {
+            "Method": "DELETE",
+            "AbsoluteUri": "https://example.com/new.txt"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "Request": {
+      "Methods": [
+        {
+          "Method": "GET"
+        }
+      ],
+      "AbsoluteUri": "https://example.com/new.txt",
+      "Disabled": true
+    },
+    "Responses": [
+      {
+        "StatusCode": 200
+      }
+    ]
+  },
+  {
+    "Request": {
+      "Methods": [
+        {
+          "Method": "DELETE"
+        }
+      ],
+      "AbsoluteUri": "https://example.com/new.txt",
+      "Disabled": true
+    },
+    "Responses": [
+      {
+        "StatusCode": 204,
+        "DisableRequests": [
+          {
+            "Method": "GET",
+            "AbsoluteUri": "https://example.com/new.txt"
+          },
+
+          {
+            "Method": "DELETE",
+            "AbsoluteUri": "https://example.com/new.txt"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=DELETE.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=DELETE.verified.txt
@@ -1,0 +1,19 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NotFound,
+    ReasonPhrase: Not Found,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: false
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=GET.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=GET.verified.txt
@@ -1,0 +1,19 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NotFound,
+    ReasonPhrase: Not Found,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: false
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,DELETE,GET.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,DELETE,GET.verified.txt
@@ -1,0 +1,53 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NoContent,
+    ReasonPhrase: No Content,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NotFound,
+    ReasonPhrase: Not Found,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: false
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,DELETE.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,DELETE.verified.txt
@@ -1,0 +1,36 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NoContent,
+    ReasonPhrase: No Content,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,GET,DELETE.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,GET,DELETE.verified.txt
@@ -1,0 +1,53 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: OK,
+    ReasonPhrase: OK,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: NoContent,
+    ReasonPhrase: No Content,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,GET.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT,GET.verified.txt
@@ -1,0 +1,36 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  },
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: OK,
+    ReasonPhrase: OK,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  }
+]

--- a/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/HttpClientTests.EnableDisable.Send_methods=PUT.verified.txt
@@ -1,0 +1,19 @@
+﻿[
+  {
+    Version: 1.1,
+    Content: {
+      Headers: [
+        {
+          Content-Length: [
+            0
+          ]
+        }
+      ]
+    },
+    StatusCode: Created,
+    ReasonPhrase: Created,
+    Headers: [],
+    TrailingHeaders: [],
+    IsSuccessStatusCode: true
+  }
+]


### PR DESCRIPTION
- Improved the `Routes` to support disabling requests based on DisableRequests
- Route fallback values for RequestHeaders & ContentHeaders
- Introduced a new `Uris` class in `Constants.cs` to store URI constants for `index.txt` and `new.txt`.
- Updated HTTP client tests to utilize the new URI constants instead of hardcoded strings.
- Added new test cases for enabling and disabling requests in `HttpClientTests`.