### PR TITLE
Remove routes caching from GetRoutes method

### DIFF
--- a/src/Devlead.Testing.MockHttp/Routes.cs
+++ b/src/Devlead.Testing.MockHttp/Routes.cs
@@ -50,8 +50,6 @@ public class Routes<T>
         return GetResponseBuilder;
     }
 
-    private static ImmutableArray<Route>? _routes;
-
     private static ImmutableDictionary<(
                         HttpMethod Method,
                         string AbsoluteUri
@@ -75,7 +73,7 @@ public class Routes<T>
         {
             lock (_lock)
             {
-                return _routes ??= ImmutableArray.Create(System.Text.Json.JsonSerializer.Deserialize<Route[]>(Resources<T>.GetString("Routes.json") ?? throw new ArgumentNullException("routesJson")) ?? throw new ArgumentNullException("routes"));
+                return ImmutableArray.Create(System.Text.Json.JsonSerializer.Deserialize<Route[]>(Resources<T>.GetString("Routes.json") ?? throw new ArgumentNullException("routesJson")) ?? throw new ArgumentNullException("routes"));
             }
         }
 


### PR DESCRIPTION
- Remove _routes static field that was caching deserialized routes
- Simplify GetRoutes to deserialize Routes.json on each invocation
- Maintain thread-safety through existing lock mechanism
- Routes are now always fresh from resource file
