### PR TITLE
Update .NET SDK and dependencies to latest versions

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.102"
+    "version": "10.0.103"
   }
 }

--- a/src/Devlead.Testing.MockHttp/Devlead.Testing.MockHttp.Dependencies.props
+++ b/src/Devlead.Testing.MockHttp/Devlead.Testing.MockHttp.Dependencies.props
@@ -11,8 +11,8 @@
         <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="8.0.1" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="8.0.1" />
     
-        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="8.0.23" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="8.0.23" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="8.0.24" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="8.0.24" />
     
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.3" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
@@ -25,11 +25,11 @@
         <PackageReference Include="Verify.Http" VersionOverride="7.4.0" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Verify.Http" Version="7.4.0" />
     
-        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="9.0.12" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="9.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="9.0.13" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="9.0.13" />
     
-        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="9.0.12" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="9.0.12" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="9.0.13" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="9.0.13" />
     
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="9.10.0" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
@@ -39,13 +39,13 @@
         <PackageReference Include="Verify.Http" VersionOverride="7.5.1" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Verify.Http" Version="7.5.1" />
     
-        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.2" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.3" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="10.0.3" />
     
-        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="10.0.2" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="10.0.2" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="10.0.3" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="10.0.3" />
     
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.2.0" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.3.0" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
       </ItemGroup>    
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,12 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Argon.Xml" Version="0.33.5" />
-    <PackageVersion Include="Verify" Version="31.12.3" />
+    <PackageVersion Include="Verify" Version="31.12.4" />
     <PackageVersion Include="Azure.Identity" Version="1.17.1" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.2.0" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.2" />
-    <PackageVersion Include="Microsoft.Extensions.Http " Version="10.0.2" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.3.0" />
+    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http " Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="MimeTypes" Version="2.5.2" />
     <PackageVersion Include="NuGetizer" Version="1.4.7" />
@@ -18,7 +18,7 @@
     <PackageVersion Include="NUnit.Analyzers" Version="4.11.2" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
-    <PackageVersion Include="Verify.NUnit" Version="31.12.3" />
+    <PackageVersion Include="Verify.NUnit" Version="31.12.4" />
     <PackageVersion Include="Verify.Http" Version="7.5.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- global.json: .NET SDK 10.0.102 → 10.0.103
- Microsoft.Net.Http.Headers: 8.0.23 → 8.0.24, 9.0.12 → 9.0.13, 10.0.2 → 10.0.3
- Microsoft.Extensions.Http: 9.0.12 → 9.0.13, 10.0.2 → 10.0.3
- Microsoft.Extensions.TimeProvider.Testing: 10.2.0 → 10.3.0
- Verify / Verify.NUnit: 31.12.3 → 31.12.4