### PR TITLE
chore(deps): align packaged dependencies and bump test packages

### DIFF
--- a/src/Devlead.Testing.MockHttp.Tests/Unit/MyServiceTests.GetUnauthorizedSecret.verified.txt
+++ b/src/Devlead.Testing.MockHttp.Tests/Unit/MyServiceTests.GetUnauthorizedSecret.verified.txt
@@ -9,5 +9,5 @@ at Devlead.Testing.MockHttp.Tests.Services.MyService.GetSecret()
 at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
 at NUnit.Framework.Internal.AsyncToSyncAdapter.Await[TResult](TestExecutionContext context, Func`1 invoke)
 at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(TestExecutionContext context, Func`1 invoke)
-at NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, String message, Object[] args)
+at NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint expression, Func`1 asyncCode, String message, Object[] args)
 }

--- a/src/Devlead.Testing.MockHttp/Devlead.Testing.MockHttp.Dependencies.props
+++ b/src/Devlead.Testing.MockHttp/Devlead.Testing.MockHttp.Dependencies.props
@@ -12,7 +12,7 @@
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="8.0.1" />
     
         <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="8.0.27" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="8.0.25" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="8.0.27" />
     
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" VersionOverride="8.0.3" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
@@ -26,10 +26,10 @@
         <PackageFile PackFolder="Dependency" Include="Verify.Http" Version="7.4.0" />
     
         <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="9.0.16" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="9.0.14" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="9.0.16" />
     
         <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="9.0.16" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="9.0.14" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="9.0.16" />
     
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="9.10.0" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="9.10.0" />
@@ -39,13 +39,13 @@
         <PackageReference Include="Verify.Http" VersionOverride="7.5.1" Pack="false" />
         <PackageFile PackFolder="Dependency" Include="Verify.Http" Version="7.5.1" />
     
-        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.3" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="10.0.3" />
+        <PackageReference Include="Microsoft.Extensions.Http" VersionOverride="10.0.8" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.Http" Version="10.0.8" />
     
-        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="10.0.5" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Net.Http.Headers" VersionOverride="10.0.8" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Net.Http.Headers" Version="10.0.8" />
     
-        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.4.0" Pack="false" />
-        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
+        <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" VersionOverride="10.6.0" Pack="false" />
+        <PackageFile PackFolder="Dependency" Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.6.0" />
       </ItemGroup>    
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -5,19 +5,19 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Argon.Xml" Version="0.33.5" />
-    <PackageVersion Include="Verify" Version="31.14.0" />
+    <PackageVersion Include="Verify" Version="31.16.3" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.4.0" />
-    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.5" />
-    <PackageVersion Include="Microsoft.Extensions.Http " Version="10.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Net.Http.Headers" Version="10.0.8" />
+    <PackageVersion Include="Microsoft.Extensions.Http " Version="10.0.8" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="MimeTypes" Version="2.5.2" />
     <PackageVersion Include="NuGetizer" Version="1.4.7" />
-    <PackageVersion Include="NUnit" Version="4.5.1" />
+    <PackageVersion Include="NUnit" Version="4.6.0" />
     <PackageVersion Include="NUnit.Analyzers" Version="4.13.0" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageVersion Include="System.Linq.Async" Version="7.0.1" />
-    <PackageVersion Include="Verify.NUnit" Version="31.14.0" />
+    <PackageVersion Include="Verify.NUnit" Version="31.16.3" />
     <PackageVersion Include="Verify.Http" Version="7.5.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Devlead.Testing.MockHttp.Dependencies.props: align PackageFile versions with PackageReference overrides for net8 (Microsoft.Net.Http.Headers 8.0.27) and net9 (Microsoft.Extensions.Http / Microsoft.Net.Http.Headers 9.0.16).
- net10: bump Microsoft.Extensions.Http and Microsoft.Net.Http.Headers to 10.0.8; bump Microsoft.Extensions.TimeProvider.Testing to 10.6.0.
- Directory.Packages.props: bump Verify and Verify.NUnit to 31.16.3; bump Microsoft.Extensions.Http and Microsoft.Net.Http.Headers to 10.0.8; set Microsoft.Extensions.TimeProvider.Testing to 10.0.8; bump NUnit to 4.6.0.